### PR TITLE
Fix typo in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ This is used by modern terminal emulators to provide functions such as folding, 
 ## Installation
 
 ```fish
-$ fisher install acomagu/fish-ocs133
+$ fisher install acomagu/fish-osc133
 ```


### PR DESCRIPTION
There was a typo in the project name in the install instructions, which stumped me for a moment when I was installing the package.

Thanks for sharing your work BTW! I'm using it to enable a shortcut for selecting the previous command's output in wezterm (similar to what's described [here](https://wezfurlong.org/wezterm/config/lua/keyassignment/SelectTextAtMouseCursor.html) in case you're interested).